### PR TITLE
[Feature request] Support for default + in positive numbers

### DIFF
--- a/TEMPLATE_README.md
+++ b/TEMPLATE_README.md
@@ -173,7 +173,7 @@ Note that even empty columns need unique names. Feel free to be as descriptive a
 
 **valign** - This _optional_ property controls the vertical alignment of the cells. It only accepts 'top' and 'bottom'. If left out, or if an improper value is used, the setting will be ignored and will use whatever css the game system provides, since as some systems already override the table css and set the whole table to top, or middle. However, if your system has css code to set valign on table properties, using valign should override the system's value.
 
-**showSign** - This _optional_ property, when used on a _direct_ or _direct-complex_ object, will show a + sign if displaying a numeric value above zero. (Useful for ability modifier display: 5 becomes +5)
+**showSign** - This _optional_ property, when used on a _direct_ or _direct-complex_ object, will show a `+` sign if displaying a numeric value above zero. (Useful for ability modifier display: `5` becomes `+5`)
 
 **text** - This property is either a **string**, **boolean**, or an **array** of objects based on if you're using **direct-complex** or not. See examples below.
 

--- a/TEMPLATE_README.md
+++ b/TEMPLATE_README.md
@@ -173,6 +173,8 @@ Note that even empty columns need unique names. Feel free to be as descriptive a
 
 **valign** - This _optional_ property controls the vertical alignment of the cells. It only accepts 'top' and 'bottom'. If left out, or if an improper value is used, the setting will be ignored and will use whatever css the game system provides, since as some systems already override the table css and set the whole table to top, or middle. However, if your system has css code to set valign on table properties, using valign should override the system's value.
 
+**showSign** - This _optional_ property, when used on a _direct_ or _direct-complex_ object, will show a + sign if displaying a numeric value above zero. (Useful for ability modifier display: 5 becomes +5)
+
 **text** - This property is either a **string**, **boolean**, or an **array** of objects based on if you're using **direct-complex** or not. See examples below.
 
 ### Text - accepted values

--- a/example_templates/dnd5e/dnd5e_modified.json
+++ b/example_templates/dnd5e/dnd5e_modified.json
@@ -122,36 +122,42 @@
         "name": "STR Mod",
         "type": "direct",
         "header": "hide",
+        "showSign": true,
         "text": "system.abilities.str.mod"
       },
       {
         "name": "DEX Mod",
         "type": "direct",
         "header": "hide",
+        "showSign": true,
         "text": "system.abilities.dex.mod"
       },
       {
         "name": "CON Mod",
         "type": "direct",
         "header": "hide",
+        "showSign": true,
         "text": "system.abilities.con.mod"
       },
       {
         "name": "INT Mod",
         "type": "direct",
         "header": "hide",
+        "showSign": true,
         "text": "system.abilities.int.mod"
       },
       {
         "name": "WIS Mod",
         "type": "direct",
         "header": "hide",
+        "showSign": true,
         "text": "system.abilities.wis.mod"
       },
       {
         "name": "CHA Mod",
         "type": "direct",
         "header": "hide",
+        "showSign": true,
         "text": "system.abilities.cha.mod"
       },
       {

--- a/src/module/app/party-sheet.js
+++ b/src/module/app/party-sheet.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-undef */
 import {
+  addSign,
   extractPropertyByString,
   getCustomSystems,
   getSelectedSystem,
@@ -245,24 +246,6 @@ export class PartySheetForm extends FormApplication {
   }
 
   /**
-   * Add a sign to a value.
-   * @param {*} value - The value to add a sign to
-   * @returns {*} The value with a sign
-   * @memberof PartySheetForm
-   */
-  addSign(value) {
-    if (typeof value === "string") {
-      const numValue = Number(value);
-      if (!isNaN(numValue) && numValue > 0 && !value.includes("+")) {
-        value = "+" + value;
-      }
-    } else if (typeof value === "number" && value > 0) {
-      value = "+" + value;
-    }
-    return value;
-  }
-
-  /**
    * Process options for a value.
    * @param {*} value - The value to process
    * @param {*} options - The options for the value
@@ -271,7 +254,7 @@ export class PartySheetForm extends FormApplication {
    */
   processOptions(value, options) {
     if (options.showSign) {
-      value = this.addSign(value);
+      value = addSign(value);
     }
     return value;
   }

--- a/src/module/utils.js
+++ b/src/module/utils.js
@@ -276,6 +276,24 @@ export function parseExtras(value, isSafeStringNeeded = false) {
 }
 
 /**
+ * Add a sign to a value.
+ * @param {string|number} value - The value to add a sign to
+ * @returns {string} The value with a sign
+ * @memberof PartySheetForm
+ */
+export function addSign(value) {
+  if (typeof value === "string") {
+    const numValue = Number(value);
+    if (!isNaN(numValue) && numValue > 0 && !value.includes("+")) {
+      value = "+" + value;
+    }
+  } else if (typeof value === "number" && value > 0) {
+    value = "+" + value.toString();
+  }
+  return value.toString();
+}
+
+/**
  * Parses out spacing elements from a string.
  * @param {string} value - The value to parse.
  * @param {boolean} isSafeStringNeeded - A boolean indicating if a SafeString is needed.

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,4 +1,11 @@
-import { parsePluses, parseSpacing, parseExtras, parseNewlines, extractPropertyByString } from "../src/module/utils";
+import {
+  parsePluses,
+  parseSpacing,
+  parseExtras,
+  parseNewlines,
+  extractPropertyByString,
+  addSign,
+} from "../src/module/utils";
 
 describe("Utils testing", () => {
   describe("Plus parsing", () => {
@@ -88,6 +95,40 @@ describe("Utils testing", () => {
       const result = parseNewlines("Hello World", false);
       expect(result.value).toEqual("Hello World");
       expect(result.isSafeStringNeeded).toEqual(false);
+    });
+  });
+
+  describe("addSign parsing", () => {
+    it("will show a negative sign", () => {
+      expect(addSign(-1)).toEqual("-1");
+    });
+
+    it("will show a positive sign", () => {
+      expect(addSign(1)).toEqual("+1");
+    });
+
+    it("will show a positive sign for a string", () => {
+      expect(addSign("1")).toEqual("+1");
+    });
+
+    it("will show a negative sign for a string", () => {
+      expect(addSign("-1")).toEqual("-1");
+    });
+
+    it("will show a positive sign for a string with a plus sign", () => {
+      expect(addSign("+1")).toEqual("+1");
+    });
+
+    it("will show a negative sign for a string with a minus sign", () => {
+      expect(addSign("-1")).toEqual("-1");
+    });
+
+    it("will not show a sign for a zero", () => {
+      expect(addSign(0)).toEqual("0");
+    });
+
+    it("will not show a sign for a string zero", () => {
+      expect(addSign("0")).toEqual("0");
     });
   });
 


### PR DESCRIPTION
Fixes #29

This PR adds a `showSign` option to the primary option list, only affecting `direct` and `direct-complex` (thus `direct`) column types. When this option is `true` it will force the display of a `+` sign on the value during output if the value is numeric and above zero.