### PR TITLE
feat(schema): added schema for templates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,13 @@
     "editor.codeActionsOnSave": {
       "source.fixAll.markdownlint": "always"
     }
-  }
+  },
+  "json.schemas": [
+    {
+      "fileMatch": [
+        "example_templates/**/*.json"
+      ],
+      "url": "./.vscode/template.schema.json"
+    }
+  ]
 }

--- a/.vscode/template.schema.json
+++ b/.vscode/template.schema.json
@@ -97,10 +97,6 @@
               "description": "Controls the row span of the cells in the column. You need also the corresponding empty rows and type 'span'.",
               "type": "number"
             },
-            "colspan": {
-              "description": "Controls the column span of the cells in the column.",
-              "type": "number"
-            },
             "text": {
               "description": "Complex property that will be parsed based on the type."
             }

--- a/.vscode/template.schema.json
+++ b/.vscode/template.schema.json
@@ -1,0 +1,177 @@
+{
+  "title": "FVTT Party Sheet Template",
+  "description": "Schema for creating and managing party sheet templates.",
+  "type": "object",
+  "required": ["name", "system", "author", "rows"],
+  "properties": {
+    "name": {
+      "description": "Name that will be displayed in the party sheet for this tempalte.",
+      "type": "string"
+    },
+    "system": {
+      "description": "The system that this template is associated with.",
+      "type": "string"
+    },
+    "author": {
+      "description": "The author of the template. Will be shown along the name of the template.",
+      "type": "string"
+    },
+    "offline_excludes_property": {
+      "description": "The actor property to do the filtering for (exclude).",
+      "type": "string",
+      "default": "actor.type"
+    },
+    "offline_excludes": {
+      "description": "List of values to exclude from the template. Based on the offline_excludes_property.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["npc"]
+    },
+    "offline_includes_property": {
+      "description": "The actor property to do the filtering for (include). If declared both offline_excludes and offline_excludes_property, will be ignored.",
+      "type": "string"
+    },
+    "offline_includes": {
+      "description": "List of values to include in the template. Based on the offline_includes_property.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "rows": {
+      "description": "The rows of the template. Keep in mind that automatically a row is created per character, this is more for data display.",
+      "type": "array",
+      "items": {
+        "description": "Specific row.",
+        "type": "array",
+        "items": {
+          "description": "The data for a row to display.",
+          "type": "object",
+          "required": ["name", "type", "header", "text"],
+          "properties": {
+            "name": {
+              "description": "The name of the row and also the header to display.",
+              "type": "string"
+            },
+            "type": {
+              "description": "The type of the row. Each type is parsed in an specific way. You can set an empty string to treat the column as an spacer.",
+              "type": "string",
+              "enum": [
+                "direct",
+                "direct-complex",
+                "string",
+                "array-string-builder",
+                "largest-from-array",
+                "smallest-from-array",
+                "object-loop",
+                "charactersheet",
+                ""
+              ]
+            },
+            "header": {
+              "description": "Whether to show the header or not.",
+              "type": "string",
+              "enum": ["show", "hide"]
+            },
+            "maxwidth": {
+              "description": "The maximum width in pixels of the row.",
+              "type": "number"
+            },
+            "minwidth": {
+              "description": "The minimum width in pixels of the row.",
+              "type": "number"
+            },
+            "valign": {
+              "description": "Vertical alignment of the cells.",
+              "type": "string",
+              "enum": ["top", "bottom"]
+            },
+            "text": {
+              "description": "Complex property that will be parsed based on the type."
+            }
+          },
+          "if": {
+            "properties": {
+              "type": {
+                "const": "direct-complex"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "text": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["type", "text"],
+                  "properties": {
+                    "type": {
+                      "description": "The type of object.",
+                      "type": "string",
+                      "enum": ["exists", "match", "match-all"]
+                    },
+                    "text": {
+                      "description": "The text that will be displayed if the type passes the check.",
+                      "type": "string"
+                    }
+                  },
+                  "allOf": [
+                    {
+                      "if": {
+                        "properties": {
+                          "type": {
+                            "const": "exists"
+                          }
+                        }
+                      },
+                      "then": {
+                        "properties": {
+                          "value": {
+                            "description": "The value that you are checking against.",
+                            "type": "string"
+                          }
+                        },
+                        "required": ["value"]
+                      }
+                    },
+                    {
+                      "if": {
+                        "properties": {
+                          "type": {
+                            "enum": ["match", "match-all"]
+                          }
+                        }
+                      },
+                      "then": {
+                        "properties": {
+                          "ifdata": {
+                            "description": "The data that will be used to validate the check on if.",
+                            "type": "string"
+                          },
+                          "matches": {
+                            "description": "The value that ifdata needs to match with.",
+                            "type": ["string", "number", "boolean"]
+                          }
+                        },
+                        "required": ["ifdata", "matches"]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "text": {
+                "type": ["string", "boolean", "number"]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.vscode/template.schema.json
+++ b/.vscode/template.schema.json
@@ -67,6 +67,7 @@
                 "smallest-from-array",
                 "object-loop",
                 "charactersheet",
+                "span",
                 ""
               ]
             },
@@ -87,6 +88,18 @@
               "description": "Vertical alignment of the cells.",
               "type": "string",
               "enum": ["top", "bottom"]
+            },
+            "showSign": {
+              "description": "Displays a '+' symbol if the value is above zero.",
+              "type": "boolean"
+            },
+            "rowspan": {
+              "description": "Controls the row span of the cells in the column. You need also the corresponding empty rows and type 'span'.",
+              "type": "number"
+            },
+            "colspan": {
+              "description": "Controls the column span of the cells in the column.",
+              "type": "number"
             },
             "text": {
               "description": "Complex property that will be parsed based on the type."

--- a/.vscode/template.schema.json
+++ b/.vscode/template.schema.json
@@ -115,6 +115,10 @@
                     "text": {
                       "description": "The text that will be displayed if the type passes the check.",
                       "type": "string"
+                    },
+                    "else": {
+                      "description": "The text that will be displayed if the type fails the check.",
+                      "type": "string"
                     }
                   },
                   "allOf": [


### PR DESCRIPTION
# Summary

Since this project relies on people editing JSON directly I thought it'd be a good idea to have an schema for it.

I added it to the `.vscode` folder and tweaked the settings. Not sure if this is the way but since it was there already it felt natural.

The conditionals work by automatically detecting type and then looking for required keys.

> It's not intended for this schema to replace documentation. It just to force checks when typing and improve intellisense.